### PR TITLE
Add copy functionality for file download links

### DIFF
--- a/static/js/components/ui-components.js
+++ b/static/js/components/ui-components.js
@@ -670,6 +670,21 @@ export class FileListComponent {
             </td>
         `;
 
+        const fileNameCell = row.querySelector('.file-name');
+        // Make the filename cell clickable and add copy functionality
+        fileNameCell.style.cursor = 'pointer';
+        fileNameCell.title = 'Click to copy download link'; // Update tooltip
+        fileNameCell.addEventListener('click', async () => {
+            try {
+                const absoluteUrl = `${window.location.origin}${file.url}`;
+                await navigator.clipboard.writeText(absoluteUrl);
+                showMessage(this.messageContainer, `Copied download link for "${file.name}" to clipboard.`, 'info', 3000); // Show short confirmation
+            } catch (err) {
+                console.error('Failed to copy link: ', err);
+                showMessage(this.messageContainer, 'Failed to copy download link.', 'error');
+            }
+        });
+
         const deleteButton = row.querySelector('button.delete');
         deleteButton.addEventListener('click', () => this.deleteFile(file.name, row)); // Pass row for potential UI feedback
 


### PR DESCRIPTION
This pull request introduces a new feature to the `FileListComponent` in `static/js/components/ui-components.js`. The change makes the filename cell clickable, allowing users to copy the download link to their clipboard.

Key changes include:

* [`static/js/components/ui-components.js`](diffhunk://#diff-6503399d42f0bc74b11264794dcdca6eedc716b313c8b2486d1764b9855ad861R673-R687): Made the filename cell clickable and added functionality to copy the download link to the clipboard. Added a tooltip to indicate this feature and provided feedback messages for success and failure cases.