### PR TITLE
Refactor endpoint routes

### DIFF
--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -545,7 +545,7 @@ func (h *Handler) ListFilesHandler(w http.ResponseWriter, r *http.Request) {
 
 // DeleteFileHandler handles deleting a converted file.
 func (h *Handler) DeleteFileHandler(w http.ResponseWriter, r *http.Request) {
-	filename := strings.TrimPrefix(r.URL.Path, "/api/delete-file/")
+	filename := strings.TrimPrefix(r.URL.Path, "/api/file/delete/")
 	if r.Method != http.MethodDelete {
 		h.sendErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -577,7 +577,7 @@ func (h *Handler) DeleteFileHandler(w http.ResponseWriter, r *http.Request) {
 
 // AbortConversionHandler handles requests to abort a conversion job.
 func (h *Handler) AbortConversionHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/abort/")
+	id := strings.TrimPrefix(r.URL.Path, "/api/conversions/abort/")
 	if r.Method != http.MethodPost {
 		h.sendErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -41,17 +41,17 @@ func NewHandler(config models.Config, converter *conversion.VideoConverter, stor
 
 // SetupRoutes configures the HTTP routes.
 func (h *Handler) SetupRoutes(mux *http.ServeMux) {
-	// API Routes (keep these first)
-	mux.HandleFunc("/api/list-videos", h.ListDriveVideosHandler)
-	mux.HandleFunc("/api/convert-from-drive", h.ConvertFromDriveHandler)
-	mux.HandleFunc("/api/upload-convert", h.UploadConvertHandler)
-	mux.HandleFunc("/api/status/", h.StatusHandler)
-	mux.HandleFunc("/api/files", h.ListFilesHandler)
-	mux.HandleFunc("/api/delete-file/", h.DeleteFileHandler)
-	mux.HandleFunc("/api/abort/", h.AbortConversionHandler)
-	mux.HandleFunc("/api/active-conversions", h.ActiveConversionsHandler)
+	// API Routes
 	mux.HandleFunc("/api/config", h.ConfigHandler)
-	mux.HandleFunc("/download/", h.DownloadHandler)
+	mux.HandleFunc("/api/videos/drive", h.ListDriveVideosHandler)
+	mux.HandleFunc("/api/convert/drive", h.ConvertFromDriveHandler)
+	mux.HandleFunc("/api/convert/upload", h.UploadConvertHandler)
+	mux.HandleFunc("/api/conversions/status", h.StatusHandler)
+	mux.HandleFunc("/api/conversions/active", h.ActiveConversionsHandler)
+	mux.HandleFunc("/api/conversions/abort", h.AbortConversionHandler)
+	mux.HandleFunc("/api/files", h.ListFilesHandler)
+	mux.HandleFunc("/api/file/delete", h.DeleteFileHandler)
+	mux.HandleFunc("/download", h.DownloadHandler)
 
 	// --- Static File Serving ---
 	staticDir := "frontend/dist"

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -46,12 +46,12 @@ func (h *Handler) SetupRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/videos/drive", h.ListDriveVideosHandler)
 	mux.HandleFunc("/api/convert/drive", h.ConvertFromDriveHandler)
 	mux.HandleFunc("/api/convert/upload", h.UploadConvertHandler)
-	mux.HandleFunc("/api/conversions/status", h.StatusHandler)
 	mux.HandleFunc("/api/conversions/active", h.ActiveConversionsHandler)
-	mux.HandleFunc("/api/conversions/abort", h.AbortConversionHandler)
+	mux.HandleFunc("/api/conversion/status/", h.StatusHandler)
+	mux.HandleFunc("/api/conversion/abort/", h.AbortConversionHandler)
 	mux.HandleFunc("/api/files", h.ListFilesHandler)
-	mux.HandleFunc("/api/file/delete", h.DeleteFileHandler)
-	mux.HandleFunc("/download", h.DownloadHandler)
+	mux.HandleFunc("/api/file/delete/", h.DeleteFileHandler)
+	mux.HandleFunc("/download/", h.DownloadHandler)
 
 	// --- Static File Serving ---
 	staticDir := "frontend/dist"
@@ -418,7 +418,7 @@ func (h *Handler) UploadConvertHandler(w http.ResponseWriter, r *http.Request) {
 
 // StatusHandler returns the status of a conversion job.
 func (h *Handler) StatusHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/status/")
+	id := strings.TrimPrefix(r.URL.Path, "/api/conversion/status/")
 	if id == "" {
 		h.sendErrorResponse(w, "Conversion ID not specified", http.StatusBadRequest)
 		return
@@ -577,7 +577,7 @@ func (h *Handler) DeleteFileHandler(w http.ResponseWriter, r *http.Request) {
 
 // AbortConversionHandler handles requests to abort a conversion job.
 func (h *Handler) AbortConversionHandler(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/conversions/abort/")
+	id := strings.TrimPrefix(r.URL.Path, "/api/conversion/abort/")
 	if r.Method != http.MethodPost {
 		h.sendErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -122,7 +122,7 @@ class ApiService {
      */
     async getConversionStatus(conversionId: string): Promise<ConversionStatus> {
         return this.apiRequest<ConversionStatus>(
-            `/api/conversions/status/${encodeURIComponent(conversionId)}`,
+            `/api/conversion/status/${encodeURIComponent(conversionId)}`,
             {},
             'getConversionStatus'
         );
@@ -169,7 +169,7 @@ class ApiService {
      */
     async abortConversion(conversionId: string): Promise<ConversionResponse> {
         return this.apiRequest<ConversionResponse>(
-            `/api/conversions/abort/${encodeURIComponent(conversionId)}`,
+            `/api/conversion/abort/${encodeURIComponent(conversionId)}`,
             { method: 'POST' }, // Using POST as it changes server state
             'abortConversion'
         );

--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -65,7 +65,7 @@ class ApiService {
      */
     async listVideos(folderId: string): Promise<Video[]> {
         return this.apiRequest<Video[]>(
-            `/api/list-videos?folderId=${encodeURIComponent(folderId)}`,
+            `/api/videos/drive?folderId=${encodeURIComponent(folderId)}`,
             {},
             'listVideos'
         );
@@ -78,7 +78,7 @@ class ApiService {
      */
     async convertFromDrive(conversionData: DriveConversionRequest): Promise<ConversionResponse> {
         return this.apiRequest<ConversionResponse>(
-            `/api/convert-from-drive`,
+            `/api/convert/drive`,
             {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -105,7 +105,7 @@ class ApiService {
         // Note: We don't set Content-Type header when using FormData with fetch,
         // the browser sets it correctly including the boundary.
         return this.apiRequest<ConversionResponse>(
-            `/api/upload-convert`,
+            `/api/convert/upload`,
             {
                 method: 'POST',
                 body: formData
@@ -122,7 +122,7 @@ class ApiService {
      */
     async getConversionStatus(conversionId: string): Promise<ConversionStatus> {
         return this.apiRequest<ConversionStatus>(
-            `/api/status/${encodeURIComponent(conversionId)}`,
+            `/api/conversions/status/${encodeURIComponent(conversionId)}`,
             {},
             'getConversionStatus'
         );
@@ -156,7 +156,7 @@ class ApiService {
      */
     async deleteFile(fileName: string): Promise<{ success: boolean; message: string }> {
         return this.apiRequest<{ success: boolean; message: string }>(
-            `/api/delete-file/${encodeURIComponent(fileName)}`,
+            `/api/file/delete/${encodeURIComponent(fileName)}`,
             { method: 'DELETE' },
             'deleteFile'
         );
@@ -169,7 +169,7 @@ class ApiService {
      */
     async abortConversion(conversionId: string): Promise<ConversionResponse> {
         return this.apiRequest<ConversionResponse>(
-            `/api/abort/${encodeURIComponent(conversionId)}`,
+            `/api/conversions/abort/${encodeURIComponent(conversionId)}`,
             { method: 'POST' }, // Using POST as it changes server state
             'abortConversion'
         );
@@ -181,7 +181,7 @@ class ApiService {
      */
     async listActiveConversions(): Promise<ConversionStatus[]> {
         // Assuming the backend returns the same structure as ConversionStatus for active ones
-        return this.apiRequest<ConversionStatus[]>('/api/active-conversions', {}, 'listActiveConversions');
+        return this.apiRequest<ConversionStatus[]>('/api/conversions/active', {}, 'listActiveConversions');
     }
 }
 


### PR DESCRIPTION
This pull request introduces a consistent and more descriptive naming convention for API endpoints across the backend and frontend codebases. The changes aim to improve clarity and maintainability by grouping related endpoints logically.

### Backend API Endpoint Updates:
* Updated routes in `backend/internal/api/handlers.go` to use a more structured naming convention. For example:
  - `/api/status/` is now `/api/conversion/status/` for conversion status checks.
  - `/api/delete-file/` is now `/api/file/delete/` for file deletion.
  - `/api/abort/` is now `/api/conversion/abort/` for aborting conversions.

### Frontend API Service Updates:
* Adjusted API calls in `frontend/src/api/apiService.ts` to match the updated backend endpoints. For example:
  - `listVideos` now calls `/api/videos/drive` instead of `/api/list-videos`.
  - `deleteFile` now calls `/api/file/delete/` instead of `/api/delete-file/`.
  - `listActiveConversions` now calls `/api/conversions/active` instead of `/api/active-conversions`.