### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -1,4 +1,5 @@
 // Package api contains HTTP handlers for the application's API endpoints
+
 package api
 
 import (
@@ -197,6 +198,10 @@ func (h *Handler) ConvertFromDriveHandler(w http.ResponseWriter, r *http.Request
 	// Use timestamp and original (sanitized) name for uniqueness and traceability
 	uploadedFileName := fmt.Sprintf("%d-%s", timestamp, sanitizedBaseName)
 	uploadedFilePath := filepath.Join(h.Config.UploadsDir, uploadedFileName)
+	if !isPathWithinDir(uploadedFilePath, h.Config.UploadsDir) {
+		h.sendErrorResponse(w, "Invalid file path", http.StatusBadRequest)
+		return
+	}
 	outputFileName := fmt.Sprintf("%s-%d.%s", fileNameWithoutExt, timestamp, request.TargetFormat)
 	outputFilePath := filepath.Join(h.Config.ConvertedDir, outputFileName)
 

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -198,10 +198,16 @@ func (h *Handler) ConvertFromDriveHandler(w http.ResponseWriter, r *http.Request
 	// Use timestamp and original (sanitized) name for uniqueness and traceability
 	uploadedFileName := fmt.Sprintf("%d-%s", timestamp, sanitizedBaseName)
 	uploadedFilePath := filepath.Join(h.Config.UploadsDir, uploadedFileName)
-	if !isPathWithinDir(uploadedFilePath, h.Config.UploadsDir) {
+
+	absUploadedFilePath, err := filepath.Abs(uploadedFilePath)
+	if err != nil || !strings.HasPrefix(absUploadedFilePath, filepath.Clean(h.Config.UploadsDir)+string(os.PathSeparator)) {
+		log.Printf("WARN: Invalid file path detected: %s", uploadedFilePath)
+
 		h.sendErrorResponse(w, "Invalid file path", http.StatusBadRequest)
 		return
 	}
+	uploadedFilePath = absUploadedFilePath
+
 	outputFileName := fmt.Sprintf("%s-%d.%s", fileNameWithoutExt, timestamp, request.TargetFormat)
 	outputFilePath := filepath.Join(h.Config.ConvertedDir, outputFileName)
 

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -201,7 +201,7 @@ func (h *Handler) ConvertFromDriveHandler(w http.ResponseWriter, r *http.Request
 
 	absUploadedFilePath, err := filepath.Abs(uploadedFilePath)
 	if err != nil || !strings.HasPrefix(absUploadedFilePath, filepath.Clean(h.Config.UploadsDir)+string(os.PathSeparator)) {
-		log.Printf("WARN: Invalid file path detected: %s", uploadedFilePath)
+		log.Printf("WARN: Invalid file path detected: %s. Error: %v", uploadedFilePath, err)
 
 		h.sendErrorResponse(w, "Invalid file path", http.StatusBadRequest)
 		return


### PR DESCRIPTION
Potential fix for [https://github.com/gatanasi/video-converter/security/code-scanning/9](https://github.com/gatanasi/video-converter/security/code-scanning/9)

To fix the issue, we need to validate the `destinationPath` to ensure it does not allow directory traversal or access to unintended files. This can be achieved by:
1. Resolving the absolute path of the `destinationPath` and ensuring it is within the intended directory (`h.Config.UploadsDir`).
2. Rejecting any paths that do not meet this criterion.

The fix involves:
- Modifying the `ConvertFromDriveHandler` function in `backend/internal/api/handlers.go` to validate the `uploadedFilePath` before passing it to `drive.DownloadFile`.
- Adding a helper function to perform the validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
