### PR TITLE
chore: Reusable workflows

### DIFF
--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -20,6 +20,9 @@ on:
         type: string
         default: 'v2.1.2'
 
+permissions:
+  contents: read
+
 jobs:
   frontend-build:
     name: Frontend Build

--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -1,0 +1,99 @@
+name: Video Converter Build Jobs
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        required: false
+        type: string
+        default: '22.x'
+      pnpm_version:
+        required: false
+        type: string
+        default: '10.9.0'
+      go_version:
+        required: false
+        type: string
+        default: '1.24'
+      go_lint_version:
+        required: false
+        type: string
+        default: 'v2.1.2'
+
+jobs:
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup pnpm ${{ inputs.pnpm_version }}
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm_version }}
+
+    - name: Use Node.js ${{ inputs.node_version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node_version }}
+        cache: 'pnpm'
+        cache-dependency-path: frontend/pnpm-lock.yaml
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build frontend
+      run: pnpm run build
+
+    - name: Run frontend tests
+      run: pnpm test
+
+  backend-build:
+    name: Backend Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go_version }}
+          check-latest: true
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run golangci-lint ${{ inputs.go_lint_version }}
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: ${{ inputs.go_lint_version }}
+          working-directory: ./backend
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Build backend
+        run: go build -v -ldflags="-s -w" -o ../video-converter-app ./cmd/server/main.go
+
+      - name: Run backend tests
+        run: go test -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'frontend/**'
       - 'backend/**'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/build-jobs.yml'
   pull_request:
     branches: [ "main" ]
 
@@ -14,85 +15,7 @@ permissions:
   contents: read
   actions: write
 
-env:
-  NODE_VERSION: '22.x'
-  PNPM_VERSION: '10.9.0'
-  GO_VERSION: '1.24'
-
 jobs:
-  frontend-build:
-    name: Frontend Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup pnpm ${{ env.PNPM_VERSION }}
-      uses: pnpm/action-setup@v4
-      with:
-        version: ${{ env.PNPM_VERSION }}
-
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: 'pnpm'
-        cache-dependency-path: frontend/pnpm-lock.yaml
-
-    - name: Install dependencies
-      run: pnpm install
-
-    - name: Build frontend
-      run: pnpm run build
-
-    - name: Run frontend tests
-      run: pnpm test
-
-  backend-build:
-    name: Backend Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./backend
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
-        with:
-          version: v2.1.2
-          working-directory: ./backend
-
-      - name: Check formatting
-        run: test -z "$(gofmt -l .)"
-
-      - name: Build backend
-        run: go build -v -ldflags="-s -w" -o ../video-converter-app ./cmd/server/main.go
-
-      - name: Run backend tests
-        run: go test -v ./...
+  build:
+    name: Build Frontend and Backend
+    uses: ./.github/workflows/build-jobs.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,11 @@ name: Video Converter CI
 
 on:
   push:
-    branches: [ "main" ]
     paths:
       - 'frontend/**'
       - 'backend/**'
       - '.github/workflows/ci.yml'
       - '.github/workflows/build-jobs.yml'
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ permissions:
   contents: write
   actions: write
 
+env:
+  NODE_VERSION: '22.x'
+  PNPM_VERSION: '10.9.0'
+  GO_VERSION: '1.24'
+
 jobs:
   determine-version:
     name: Determine Next Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,6 @@ permissions:
   contents: write
   actions: write
 
-env:
-  NODE_VERSION: '22.x'
-  PNPM_VERSION: '10.9.0'
-  GO_VERSION: '1.24'
-
 jobs:
   determine-version:
     name: Determine Next Version
@@ -106,95 +101,16 @@ jobs:
             fi
           fi
 
-  frontend-build:
-    name: Frontend Build
-    runs-on: ubuntu-latest
+  build:
+    name: Build Frontend and Backend
     needs: determine-version
     if: needs.determine-version.outputs.should_release == 'true'
-    defaults:
-      run:
-        working-directory: ./frontend
-    steps:
-    - name: Checkout code from specified branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.inputs.branch }}
-    - name: Setup pnpm ${{ env.PNPM_VERSION }}
-      uses: pnpm/action-setup@v4
-      with:
-        version: ${{ env.PNPM_VERSION }}
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: 'pnpm'
-        cache-dependency-path: frontend/pnpm-lock.yaml
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-    - name: Build frontend
-      run: pnpm run build
-    - name: Run frontend tests
-      run: pnpm test
-    - name: Upload frontend artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: frontend-build
-        path: frontend/dist
-
-  backend-build:
-    name: Backend Build
-    runs-on: ubuntu-latest
-    needs: determine-version
-    if: needs.determine-version.outputs.should_release == 'true'
-    defaults:
-      run:
-        working-directory: ./backend
-    steps:
-      - name: Checkout code from specified branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Install dependencies
-        run: go mod download
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
-        with:
-          version: v2.1.2
-          working-directory: ./backend
-      - name: Check formatting
-        run: test -z "$(gofmt -l .)" || (echo "Go code is not formatted. Run 'gofmt -w .' "; exit 1)
-      - name: Build backend with version
-        env:
-          NEXT_VERSION: ${{ needs.determine-version.outputs.next_version }}
-        run: |
-          echo "Building backend version: $NEXT_VERSION"
-          go build -v -trimpath -ldflags="-X main.version=$NEXT_VERSION -s -w" -o ../video-converter-app ./cmd/server/main.go
-      - name: Run backend tests
-        run: go test -v -race ./...
-      - name: Upload backend artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-build
-          path: video-converter-app
+    uses: ./.github/workflows/build-jobs.yml
 
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [determine-version, frontend-build, backend-build]
+    needs: [determine-version, build]
     if: needs.determine-version.outputs.should_release == 'true'
     permissions:
       contents: write


### PR DESCRIPTION
This pull request refactors the CI/CD workflows for the video converter project by introducing a reusable workflow for build jobs and updating existing workflows to use it. The changes aim to improve maintainability and reduce redundancy in the workflow definitions.

### Introduction of Reusable Workflow:
* Added a new reusable workflow, `build-jobs.yml`, that defines separate `frontend-build` and `backend-build` jobs. This workflow supports customizable inputs for Node.js, pnpm, Go, and Go linter versions. It includes steps for dependency installation, building, testing, and linting for both the frontend and backend.

### Updates to CI Workflow:
* Refactored the `ci.yml` workflow to replace inlined frontend and backend build jobs with a single reusable `build` job that references `build-jobs.yml`. Removed hardcoded environment variables and adjusted the workflow triggers to include changes to `build-jobs.yml`.

### Updates to Release Workflow:
* Simplified the `release.yml` workflow by replacing the separate `frontend-build` and `backend-build` jobs with a single reusable `build` job from `build-jobs.yml`. Updated dependencies between jobs to reflect the new structure.