### PR TITLE
chore: Update Renovate configuration to best practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,34 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "npm:unpublishSafe"
+  ],
+  "schedule": ["after 8pm on sunday"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "separateMajorMinor": true
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "all non-major devDependencies",
+      "groupSlug": "non-major-dev-deps"
+    },
+    {
+      "matchDatasources": ["github-actions"],
+      "groupName": "github actions",
+      "groupSlug": "github-actions"
+    }
   ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration file to enhance dependency management practices by adopting best practices, improving scheduling, and adding rules for grouping updates.

### Configuration improvements:

* Replaced the `config:recommended` preset with `config:best-practices`, and added `helpers:pinGitHubActionDigestsToSemver` and `npm:unpublishSafe` for better dependency and GitHub Actions management.
* Introduced a schedule to run Renovate updates after 8 PM on Sundays.

### Dependency grouping:

* Added rules to group major updates separately and organize non-major updates for `dependencies` and `devDependencies` into distinct groups for easier review.
* Created a specific group for updates related to GitHub Actions.